### PR TITLE
User-defined puzzle support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import "./App.css";
 import Classic from "./pages/Classic";
 import Home from "./pages/Home";
 import Tutorial from "./pages/Tutorial";
+import Create from "./pages/Create";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material";
@@ -48,6 +49,10 @@ function App() {
             <Route path="/tutorial">
               <Title title="Subsolver - Tutorial" />
               <Tutorial />
+            </Route>
+            <Route path="/create">
+              <Title title="Subsolver - Create new puzzle" />
+              <Create />
             </Route>
             <Route path="/test">
               <TouchscreenInputHandler />

--- a/src/CopyTextButton.tsx
+++ b/src/CopyTextButton.tsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import Button, { ButtonProps } from "@mui/material/Button";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import CheckIcon from "@mui/icons-material/Check";
+
+export const CopyTextButton = ({onClick, children, ...props}: ButtonProps) => {
+  const [showDoneIcon, setShowDoneIcon] = useState(false);
+
+  const handleClick: typeof onClick = (event) => {
+    onClick?.(event);
+
+    // Show visual indication of successful operation for 2 seconds
+    setShowDoneIcon(true);
+    setTimeout(() => setShowDoneIcon(false), 2000);
+  };
+
+  return <Button
+    {...props}
+    onClick={handleClick}
+    endIcon={showDoneIcon ? <CheckIcon /> : <ContentCopyIcon />}
+  >
+    {children}
+  </Button>;
+};

--- a/src/fb.ts
+++ b/src/fb.ts
@@ -2,14 +2,14 @@ import { recordEvent } from "./tracking";
 
 export const shareTime = (puzzleId: string, time: string) => {
   recordEvent("ss_facebook_share_click", {
-    puzzleId,
+    puzzleId: puzzleId || "custom",
     solveTime: time,
   });
   (window as any).FB.ui(
     {
       method: "share",
       href: window.location.href,
-      quote: `I cracked puzzle #${puzzleId} in ${time} on Subsolver! Can you beat it?`,
+      quote: `I cracked ${puzzleId ? `puzzle #${puzzleId}` : "custom puzzle"} in ${time} on Subsolver! Can you beat it?`,
     },
     function (response: any) {}
   );

--- a/src/layout/PageHeader.css
+++ b/src/layout/PageHeader.css
@@ -1,0 +1,13 @@
+.page-header {
+  text-align: center;
+}
+
+.page-header .back-button {
+  position: absolute;
+  left: 0;
+  padding: 0 1.5rem;
+  line-height: 36px;
+  font-size: 1rem;
+  color: white;
+  text-decoration: none;
+}

--- a/src/layout/PageHeader.tsx
+++ b/src/layout/PageHeader.tsx
@@ -1,0 +1,19 @@
+import "./PageHeader.css";
+import { Link } from "react-router-dom";
+
+interface PageHeaderProps {
+  headerText: string;
+}
+
+const PageHeader = ({ headerText }: PageHeaderProps) => {
+  return (
+    <header className="page-header">
+      <Link to="/" className="back-button">
+        ⟨ Back
+      </Link>
+      <h2>Subsolver: {headerText}</h2>
+    </header>
+  );
+};
+
+export default PageHeader;

--- a/src/pages/Classic.css
+++ b/src/pages/Classic.css
@@ -62,20 +62,6 @@
   color: lightgray;
 }
 
-.classic-page header {
-  text-align: center;
-}
-
-.classic-page .back-button {
-  position: absolute;
-  left: 0;
-  padding: 0rem 1.5rem;
-  line-height: 36px;
-  font-size: 1rem;
-  color: white;
-  text-decoration: none;
-}
-
 .success-button-group {
   padding: 0.5rem;
   display: flex;

--- a/src/pages/Classic.css
+++ b/src/pages/Classic.css
@@ -36,6 +36,7 @@
   position: absolute;
   padding: 0 2rem;
   font-size: 1.1rem;
+  width: 100%;
   height: 100%;
   box-shadow: 0px 0px 6px -2px lime inset;
 }

--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -6,7 +6,6 @@ import { Button } from "@mui/material";
 import { choose, decodeBase64 } from "../util";
 import ShareIcon from '@mui/icons-material/Share';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import "./Classic.css";
 import { getAllSolved, setSolved } from "../solvedStore";
 import {
@@ -22,6 +21,7 @@ import { recordEvent } from "../tracking";
 import getInputSchema from "../inputTypes";
 import { cameFromFacebook, shareTime } from "../fb";
 import PageHeader from "../layout/PageHeader";
+import { CopyTextButton } from "../CopyTextButton";
 
 interface ClassicProps {
   headerText: string;
@@ -105,14 +105,13 @@ const ClassicPuzzle = ({
                 >
                   Share
                 </Button>
-              : <Button
+              : <CopyTextButton
                   onClick={() => copyShareText(plainText.id, solvedTime)}
                   variant="contained"
                   color="success"
-                  endIcon={<ContentCopyIcon />}
                 >
                   Share
-                </Button>
+                </CopyTextButton>
             }
 
             <Button

--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -28,9 +28,9 @@ interface ClassicProps {
 }
 
 const copyShareText = (id: string, solvedTime: string) => {
-  const str = `Subsolver #${id} solved in ${solvedTime}!\n\nAttempt this same puzzle at ${window.location.href}`;
+  const str = `${id ? `Subsolver #${id}` : "Custom Subsolver"} solved in ${solvedTime}!\n\nAttempt this same puzzle at ${window.location.href}`;
   recordEvent("ss_copy_share", {
-    puzzleId: id
+    puzzleId: id || "custom"
   });
   navigator.clipboard.writeText(str);
 }
@@ -64,9 +64,9 @@ const ClassicPuzzle = ({
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     recordEvent("ss_puzzle_start", {
-      puzzleId: plainText.id,
+      puzzleId: plainText.id || "custom",
     });
-    pushEvent(`Started puzzle #${plainText.id}`);
+    pushEvent(plainText.id ? `Started puzzle #${plainText.id}` : "Started custom puzzle");
   }, []);
 
   return (
@@ -74,7 +74,9 @@ const ClassicPuzzle = ({
       plaintext={plainText}
       key={plainText.text}
       onComplete={() => {
-        setSolved(plainText.id);
+        if (plainText.id) {
+          setSolved(plainText.id);
+        }
         forceUpdate();
       }}
       pushEvent={pushEvent}
@@ -154,7 +156,7 @@ const ClassicPageContents = ({
   return (
     <article className="main-content">
       <header className="puzzle-header">
-        <span>Puzzle #{plainText.id}</span>
+        <span>{plainText.id ? `Puzzle #${plainText.id}` : "Custom puzzle"}</span>
         <span>
           {getAllSolved().length} / {plaintexts.length} Solved
         </span>
@@ -164,7 +166,7 @@ const ClassicPageContents = ({
         startNewPuzzle={startNewPuzzle}
         plainText={plainText}
         pushEvent={pushEvent}
-        key={plainText.id}
+        key={puzzleId}
       />
       <p>{getInputSchema().bottomHelpText}</p>
       <input type="text" id="puzzle-self-link" value={window.location.href} />

--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -142,9 +142,14 @@ const ClassicPageContents = ({
   basePath,
 }: ClassicPageContentsProps) => {
   let { puzzleId } = useParams() as { puzzleId: string };
-  const plainText = plaintexts.find((plain) => plain.id === puzzleId);
+  let plainText = plaintexts.find((plain) => plain.id === puzzleId);
   if (!plainText) {
-    return <Redirect to={basePath} />;
+    try {
+      plainText = JSON.parse(atob(puzzleId)) as Plaintext;
+    } catch (e) {
+      console.error("Failed to parse custom puzzle from URL:", e);
+      return <Redirect to={basePath} />;
+    }
   }
   return (
     <article className="main-content">

--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -10,7 +10,6 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import "./Classic.css";
 import { getAllSolved, setSolved } from "../solvedStore";
 import {
-  Link,
   Switch,
   Route,
   useRouteMatch,
@@ -21,6 +20,7 @@ import {
 import { recordEvent } from "../tracking";
 import getInputSchema from "../inputTypes";
 import { cameFromFacebook, shareTime } from "../fb";
+import PageHeader from "../layout/PageHeader";
 
 interface ClassicProps {
   headerText: string;
@@ -184,12 +184,7 @@ const ClassicRouter = ({ gameModifiers, headerText }: ClassicProps) => {
 
   return (
     <div className="classic-page">
-      <header>
-        <Link to="/" className="back-button">
-          ⟨ Back
-        </Link>
-        <h2>Subsolver: {headerText}</h2>
-      </header>
+      <PageHeader headerText={headerText} />
       <Switch>
         <Route path={`${path}/:puzzleId`}>
           <ClassicPageContents

--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -3,7 +3,7 @@ import Puzzle, { GameModifiers } from "../puzzle/Puzzle";
 import EventStream from "../EventStream";
 import plaintexts, { Plaintext } from "../plaintexts";
 import { Button } from "@mui/material";
-import { choose } from "../util";
+import { choose, decodeBase64 } from "../util";
 import ShareIcon from '@mui/icons-material/Share';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -151,7 +151,7 @@ const ClassicPageContents = ({
   const plainText = useMemo(() => {
     if (puzzleId === "custom") {
       try {
-        return JSON.parse(atob(decodeURIComponent(hash.substring(1)))) as Plaintext;
+        return JSON.parse(decodeBase64(decodeURIComponent(hash.substring(1)))) as Plaintext;
       } catch (e) {
         console.error("Failed to parse custom puzzle from URL:", e);
         window.alert("Failed to parse custom puzzle");

--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -86,8 +86,10 @@ const ClassicPuzzle = ({
             <h3>Puzzle Solved in {solvedTime}</h3>
             <p>{plainText.text}</p>
             <div className="success-author-origin">
-              <i>—{plainText.author}</i>
-              <br />
+              {!!plainText.author && <>
+                  <i>—{plainText.author}</i>
+                  <br />
+              </>}
               {plainText.origin}
             </div>
           </div>

--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -149,7 +149,7 @@ const ClassicPageContents = ({
   let plainText = plaintexts.find((plain) => plain.id === puzzleId);
   if (!plainText) {
     try {
-      plainText = JSON.parse(atob(puzzleId)) as Plaintext;
+      plainText = JSON.parse(atob(decodeURIComponent(puzzleId))) as Plaintext;
     } catch (e) {
       console.error("Failed to parse custom puzzle from URL:", e);
       return <Redirect to={basePath} />;

--- a/src/pages/Create.css
+++ b/src/pages/Create.css
@@ -1,0 +1,4 @@
+.create-page {
+  text-align: center;
+  font-size: 1rem;
+}

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -23,7 +23,7 @@ const Create = () => {
       origin,
     };
     const encodedPlaintext = btoa(JSON.stringify(plaintext));
-    const link = window.location.origin + generatePath("/classic/:data", {data: encodedPlaintext});
+    const link = window.location.origin + generatePath("/casual/custom#:data", {data: encodedPlaintext});
 
     navigator.clipboard.writeText(link);
   };

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,6 +1,6 @@
 import "./Create.css";
 import { useState, KeyboardEvent } from "react";
-import { Alert, Button, Grid, TextField } from "@mui/material";
+import {Alert, Button, FormControl, Grid, InputLabel, MenuItem, Select, TextField} from "@mui/material";
 import PageHeader from "../layout/PageHeader";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { generatePath } from "react-router-dom";
@@ -13,6 +13,7 @@ const Create = () => {
   const [text, setText] = useState("");
   const [author, setAuthor] = useState("");
   const [origin, setOrigin] = useState("");
+  const [mode, setMode] = useState("casual");
 
   const isTooShort = text.trim().length < minLength;
 
@@ -24,7 +25,7 @@ const Create = () => {
       origin,
     };
     const encodedPlaintext = encodeBase64(JSON.stringify(plaintext));
-    const link = window.location.origin + generatePath("/casual/custom#:data", {data: encodedPlaintext});
+    const link = window.location.origin + generatePath("/:mode/custom#:data", {mode, data: encodedPlaintext});
 
     navigator.clipboard.writeText(link);
   };
@@ -62,7 +63,23 @@ const Create = () => {
             </Alert>}
           </Grid>
 
-          <Grid item xs={12} sm={4}>
+          <Grid item xs={6} sm={3}>
+            <FormControl fullWidth={true}>
+              <InputLabel id={"mode-label"}>Mode</InputLabel>
+              <Select
+                label={"Mode"}
+                labelId={"mode-label"}
+                value={mode}
+                onChange={(event) => setMode(event.target.value)}
+              >
+                <MenuItem value={"classic"}>Classic</MenuItem>
+                <MenuItem value={"casual"}>Casual</MenuItem>
+                <MenuItem value={"hard"}>Hardcore</MenuItem>
+              </Select>
+            </FormControl>
+          </Grid>
+
+          <Grid item xs={6} sm={3}>
             <TextField
               value={author}
               onChange={(event) => setAuthor(event.target.value)}
@@ -71,7 +88,7 @@ const Create = () => {
             />
           </Grid>
 
-          <Grid item xs={12} sm={8}>
+          <Grid item xs={12} sm={6}>
             <TextField
               value={origin}
               onChange={(event) => setOrigin(event.target.value)}

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,11 +1,11 @@
 import "./Create.css";
 import { useState, KeyboardEvent } from "react";
-import {Alert, Button, FormControl, Grid, InputLabel, MenuItem, Select, TextField} from "@mui/material";
+import {Alert, FormControl, Grid, InputLabel, MenuItem, Select, TextField} from "@mui/material";
 import PageHeader from "../layout/PageHeader";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { generatePath } from "react-router-dom";
 import { Plaintext } from "../plaintexts";
 import { encodeBase64 } from "../util";
+import { CopyTextButton } from "../CopyTextButton";
 
 const minLength = 20;
 
@@ -98,16 +98,15 @@ const Create = () => {
           </Grid>
 
           <Grid item xs={12}>
-            <Button
+            <CopyTextButton
               onClick={copyLink}
               disabled={isTooShort}
               size="large"
               variant="contained"
               color="primary"
-              endIcon={<ContentCopyIcon/>}
             >
               Share the link
-            </Button>
+            </CopyTextButton>
           </Grid>
         </Grid>
       </article>

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,0 +1,100 @@
+import "./Create.css";
+import { useState, KeyboardEvent } from "react";
+import { Alert, Button, Grid, TextField } from "@mui/material";
+import PageHeader from "../layout/PageHeader";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { generatePath } from "react-router-dom";
+import { Plaintext } from "../plaintexts";
+
+const minLength = 20;
+
+const Create = () => {
+  const [text, setText] = useState("");
+  const [author, setAuthor] = useState("");
+  const [origin, setOrigin] = useState("");
+
+  const isTooShort = text.trim().length < minLength;
+
+  const copyLink = () => {
+    const plaintext: Plaintext = {
+      id: "",
+      text,
+      author,
+      origin,
+    };
+    const encodedPlaintext = btoa(JSON.stringify(plaintext));
+    const link = window.location.origin + generatePath("/classic/:data", {data: encodedPlaintext});
+
+    navigator.clipboard.writeText(link);
+  };
+
+  const stopPropagation = (event: KeyboardEvent) => {
+    // Stop keyboard events of this page from getting processed by KeysPressed,
+    // and let the user type text with spaces freely.
+    event.stopPropagation();
+  };
+
+  return (
+    <div
+      className="create-page"
+      onKeyDown={stopPropagation}
+      onKeyUp={stopPropagation}
+    >
+      <PageHeader headerText={"Create new puzzle"}/>
+
+      <article className="main-content">
+        <Grid container spacing={1}>
+          <Grid item xs={12}>
+            <TextField
+              value={text}
+              onChange={(event) => setText(event.target.value)}
+              label={"Text"}
+              placeholder={"Enter the puzzle phrase to be solved"}
+              fullWidth={true}
+              multiline={true}
+              minRows={5}
+              autoFocus={true}
+            />
+
+            {isTooShort && <Alert severity={"info"}>
+                Please type at least {minLength} letters to create a puzzle
+            </Alert>}
+          </Grid>
+
+          <Grid item xs={12} sm={4}>
+            <TextField
+              value={author}
+              onChange={(event) => setAuthor(event.target.value)}
+              label={"Author"}
+              fullWidth={true}
+            />
+          </Grid>
+
+          <Grid item xs={12} sm={8}>
+            <TextField
+              value={origin}
+              onChange={(event) => setOrigin(event.target.value)}
+              label={"Origin"}
+              fullWidth={true}
+            />
+          </Grid>
+
+          <Grid item xs={12}>
+            <Button
+              onClick={copyLink}
+              disabled={isTooShort}
+              size="large"
+              variant="contained"
+              color="primary"
+              endIcon={<ContentCopyIcon/>}
+            >
+              Share the link
+            </Button>
+          </Grid>
+        </Grid>
+      </article>
+    </div>
+  );
+};
+
+export default Create;

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -5,6 +5,7 @@ import PageHeader from "../layout/PageHeader";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { generatePath } from "react-router-dom";
 import { Plaintext } from "../plaintexts";
+import { encodeBase64 } from "../util";
 
 const minLength = 20;
 
@@ -22,7 +23,7 @@ const Create = () => {
       author,
       origin,
     };
-    const encodedPlaintext = btoa(JSON.stringify(plaintext));
+    const encodedPlaintext = encodeBase64(JSON.stringify(plaintext));
     const link = window.location.origin + generatePath("/casual/custom#:data", {data: encodedPlaintext});
 
     navigator.clipboard.writeText(link);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -56,11 +56,18 @@ const Home = () => (
             description="Spaces have been removed!"
           />
         </Grid>
-        <Grid item xs={12}>
+        <Grid item xs={6}>
           <GameModeLink
             to="/tutorial"
             title="Tutorial"
             description="Learn the basics of how to play this game!"
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <GameModeLink
+            to="/create"
+            title="Create"
+            description="Build your own puzzle and share it with your friends!"
           />
         </Grid>
       </Grid>

--- a/src/puzzle/Puzzle.css
+++ b/src/puzzle/Puzzle.css
@@ -17,6 +17,11 @@
   color: #aaa;
 }
 
+/* Make the puzzle overlay big enough to have space for minimal success overlay */
+.puzzle .cipher-text-display {
+  min-height: 12rem;
+}
+
 .puzzle-letter {
   animation: letter_change ease-out 1s;
 }

--- a/src/puzzle/Puzzle.tsx
+++ b/src/puzzle/Puzzle.tsx
@@ -64,16 +64,16 @@ function Puzzle({
     } else if (lockedLetters.has(b)) {
       pushFailedSwap(b);
     } else {
-      recordEvent("ss_swap", { a, b, puzzleId: id });
+      recordEvent("ss_swap", { a, b, puzzleId: id || "custom" });
       const newMapping = swapLetters(mapping, a, b);
       setMapping(newMapping);
       pushEvent(`"${a.toUpperCase()}" and "${b.toUpperCase()}" swapped.`);
       if (applyMapping(text, newMapping) === applyMapping(text, alphabet)) {
-        pushEvent(`Puzzle #${id} solved`);
+        pushEvent(id ? `Puzzle #${id} solved` : "Custom puzzle solved");
         const allSolved = getAllSolved();
         const puzzleEndTime = new Date();
         recordEvent("ss_solve", {
-          puzzleId: id,
+          puzzleId: id || "custom",
           startTime: puzzleStartTime!.toJSON(),
           endTime: puzzleEndTime.toJSON(),
           solvedTime: getSolvedTime(),
@@ -102,7 +102,7 @@ function Puzzle({
     recordEvent("ss_toggle_letter_locked", {
       letter,
       locked: locked.toString(),
-      puzzleId: id,
+      puzzleId: id || "custom",
     });
     const newSet = new Set(lockedLetters);
     if (locked) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -48,3 +48,17 @@ export function hrTime(millis: number): string {
   }
   return returntext.trim();
 }
+
+// Encode string to base64, supporting UTF characters
+export function encodeBase64(value: string) {
+  const binArray = Array.from(new TextEncoder().encode(value));
+  const binString = String.fromCodePoint(...binArray);
+  return btoa(binString);
+}
+
+// Decode string from base64, supporting UTF characters
+export function decodeBase64(base64: string) {
+  const binString = atob(base64);
+  const binArray = Uint8Array.from(binString, (m) => m.codePointAt(0)!);
+  return new TextDecoder().decode(binArray);
+}


### PR DESCRIPTION
According to discussion in https://github.com/evinism/subsolver2/issues/3 , this PR adds a page for creating and sharing custom puzzles.

Functionality:
- Add a new button to the home page that leads to a dedicated page for creating and sharing user-defined puzzles.
  <img width="505" alt="image" src="https://github.com/user-attachments/assets/0a57d86d-8a39-42e0-a53c-cdaf254a14fa" />
- Add a puzzle creation page that allows to write custom puzzle text, author and origin, and create a link for solving it.
  <img width="646" alt="image" src="https://github.com/user-attachments/assets/597af405-b48a-4645-a919-1c469c6caa73" /> <img width="650" alt="image" src="https://github.com/user-attachments/assets/4a7cebbd-871b-4d4f-9c5a-3fa100c9869d" />
- Modify the main puzzle solving page to support custom puzzles.

Technical implementation:
- Create a `Plaintext` object from the user-defined fields from the form, with an empty ID. Empty ID is being used as an indication that the puzzle is custom.
- The puzzle data is JSON-decoded, then base64-encoded, and used as a puzzle ID in the puzzle solving page routes, e.g. `/classic/:base64-encoded-data`.
- The solving page takes the puzzle ID from the URL and tries to find a pre-defined puzzle with this ID first. If there's no match then it tries to decode it as a custom puzzle data. If the decoding attempt fails, the user gets redirected to the home page.

Open questions and investment areas:
- The pre-defined puzzles have nice short IDs, but user-defined puzzles can't have them. Currently, the page builds a custom puzzle with empty ID, writes `"custom puzzle"` instead of `"puzzle #:id"` in the UI, and sends "custom" instead of the puzzle ID to the analytics. Not sure if it was right decision, and what's the alternative. Theoretically, could use unix timestamp or a random guid as an ID during generation and display/send it as is.
- Currently, the puzzle builder creates only links to the "classic" mode. Not sure if the mode should be selected by the puzzle creator while generating the link, or if there should be a dedicated page for the person who solves a custom puzzle to select the mode. Alternatively, could generate classic mode links by default, but allow switching the mode right in the solving page.