### PR TITLE
replace "next puzzle" button for custom puzzles with a home link

### DIFF
--- a/src/pages/Classic.tsx
+++ b/src/pages/Classic.tsx
@@ -62,12 +62,14 @@ const ClassicPuzzle = ({
 }: ClassicPuzzleProps) => {
   const forceUpdate = useReducer((x) => x + 1, 0)[1];
 
+  const isCustomPuzzle = !plainText.id;
+
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     recordEvent("ss_puzzle_start", {
       puzzleId: plainText.id || "custom",
     });
-    pushEvent(plainText.id ? `Started puzzle #${plainText.id}` : "Started custom puzzle");
+    pushEvent(isCustomPuzzle ? "Started custom puzzle" : `Started puzzle #${plainText.id}`);
   }, []);
 
   return (
@@ -114,14 +116,21 @@ const ClassicPuzzle = ({
                 </CopyTextButton>
             }
 
-            <Button
+            {!isCustomPuzzle && <Button
               onClick={startNewPuzzle}
               variant="contained"
               color="success"
-              endIcon={<ArrowRightIcon />}
+              endIcon={<ArrowRightIcon/>}
             >
               Next Puzzle
-            </Button>
+            </Button>}
+            {isCustomPuzzle && <Button
+              href={"/"}
+              variant="contained"
+              color="success"
+            >
+              All Puzzles
+            </Button>}
           </div>
         </div>
       )}


### PR DESCRIPTION
The "next puzzle" button in the success screen makes less sense for custom puzzles. People who see the site for the first time don't understand that it will redirect them from custom-made puzzles to the pre-defined ones. They tend to think that it's a series of custom-made puzzles that the person who sent a link prepared for them.
This PR replaces the button with a link that leads to the home page for custom puzzles (while built-in puzzles still have the "next puzzle" button).