### PR TITLE
reduce initial mapping to only letters that exist in the plaintext

### DIFF
--- a/src/puzzle/mapping.ts
+++ b/src/puzzle/mapping.ts
@@ -71,10 +71,19 @@ const _getLetterCounts = (normalizedText: string) => {
 
 export const findInitialMapping = (text: string) => {
   const normalized = _normalizeText(text, { hideSpaces: true });
-  const letterCounts = Object.entries(_getLetterCounts(normalized));
+  const letterCountsObj = _getLetterCounts(normalized);
+  const frequencyOrderArr = frequencyOrder.split("");
+
+  const initialReplacementOrder =
+    frequencyOrderArr.filter((letter) => letterCountsObj[letter] > 0).join("") +
+    frequencyOrderArr
+      .filter((letter) => letterCountsObj[letter] === 0)
+      .join("");
+
+  const letterCounts = Object.entries(letterCountsObj);
   letterCounts.sort((a, b) => b[1] - a[1]);
   const mappingEntries = letterCounts.map(([letter], index) => [
-    frequencyOrder[index],
+    initialReplacementOrder[index],
     letter,
   ]);
   mappingEntries.sort(([a], [b]) => a.localeCompare(b));


### PR DESCRIPTION
Instad of just blindly applying the frequency order, we restrict to frequency order that exists in the plaintext. Code still has the full mapping, but unused characters won't be displayed and there's now no reason for users to swap to them, even if they still technically can.


Current:
<img width="988" height="445" alt="Screenshot 2025-09-08 at 9 42 30 AM" src="https://github.com/user-attachments/assets/7e46194a-0a8b-40ef-b056-3f5cd7a2c244" />

New:
<img width="977" height="452" alt="Screenshot 2025-09-08 at 9 46 38 AM" src="https://github.com/user-attachments/assets/b8dfef41-b9db-454b-a385-58c16c79e189" />


Addresses: https://github.com/evinism/subsolver2/issues/9
